### PR TITLE
fix issue #80 - remove clash method inspectVariable from Jade UI

### DIFF
--- a/sources/Jade Autocompletation Enhancements.pax
+++ b/sources/Jade Autocompletation Enhancements.pax
@@ -3,12 +3,9 @@ package := Package name: 'Jade Autocompletation Enhancements'.
 package paxVersion: 1;
 	basicComment: ''.
 
-package basicPackageVersion: '0.053'.
+package basicPackageVersion: '0.054'.
 
-package basicScriptAt: #preinstall put: '(JadeServer classVarNames includes: ''PackageOrganizer'')
-ifFalse: [JadeServer addClassVarName: ''PackageOrganizer''].
-
-#(''inspector'' ''sunitPresenter'' ''inspectorContainer'' ''oopPresenter'' ''autoInfoPresenter'') do: [:instVarName | 
+package basicScriptAt: #preinstall put: '#(''inspector'' ''sunitPresenter'' ''inspectorContainer'' ''oopPresenter'' ''autoInfoPresenter'') do: [:instVarName | 
 	(JadeAutoSystemBrowserPresenter instVarNames includes: instVarName) ifFalse: [JadeAutoSystemBrowserPresenter addInstVarName: instVarName]].
 '.
 

--- a/sources/JadeDebugger.cls
+++ b/sources/JadeDebugger.cls
@@ -95,13 +95,6 @@ initializeProcess: aProcess message: aString terminateOnClose: aBoolean
 	self update.
 !
 
-inspectVariable
-
-	| object |
-	object := gciSession oopTypeWithOop: variableListPresenter selection key key asNumber.
-	JadeInspector showOn: object session: gciSession.
-!
-
 onViewClosed
 
 	gsProcess := processList first.
@@ -322,7 +315,6 @@ updateSaveMethod
 !JadeDebugger categoriesFor: #getProcessList!public! !
 !JadeDebugger categoriesFor: #implement!public! !
 !JadeDebugger categoriesFor: #initializeProcess:message:terminateOnClose:!public! !
-!JadeDebugger categoriesFor: #inspectVariable!public! !
 !JadeDebugger categoriesFor: #onViewClosed!public! !
 !JadeDebugger categoriesFor: #queryCommand:!public! !
 !JadeDebugger categoriesFor: #resumeProcess!public! !


### PR DESCRIPTION
BootJade.cmd create a clean image now.
The existing method inspectVariable in JadeDebugger was the clash.
This method was moved to Jade Inspector Enhacements