### PR TITLE
Refactor nonEmptySubStrings: to subStringsTrimmingTrailingEmptyElement:

### DIFF
--- a/sources/CodeSourcePresenter.cls
+++ b/sources/CodeSourcePresenter.cls
@@ -184,20 +184,20 @@ fileSave
 	^parentPresenter fileSave!
 
 findClassList
-"
+	"
 	Array with: className with: dictionaryName with: catetory with: packageName.
 "
+
 	| string list |
-	string := self gciSession 
-		serverPerform: #'systemBrowser:' 
-		with: (self gciSession encode: '0 findClass').
+	string := self gciSession serverPerform: #systemBrowser:
+				with: (self gciSession encode: '0 findClass').
 	string := self gciSession decode: string.
-	list := (string nonEmptySubStrings: Character lf) collect: [:each | each subStrings: Character tab].
+	list := (string subStringsTrimmingTrailingEmptyElement: Character lf)
+				collect: [:each | each subStrings: Character tab].
 	list := list copyFrom: 2 to: list size.
 	list := list collect: [:each | each size < 3 ifTrue: [each , #('' '' '')] ifFalse: [each]].
 	list := list collect: [:each | (each at: 1) -> each].
-	^list
-!
+	^list!
 
 handleInvalidSession
 

--- a/sources/GemStone Objects.pax
+++ b/sources/GemStone Objects.pax
@@ -17,7 +17,7 @@ package classNames
 	yourself.
 
 package methodNames
-	add: #String -> #nonEmptySubStrings:;
+	add: #String -> #subStringsTrimmingTrailingEmptyElement:;
 	yourself.
 
 package binaryGlobalNames: (Set new
@@ -73,12 +73,19 @@ ReadStream subclass: #JadeServerReadStream
 
 !String methodsFor!
 
-nonEmptySubStrings: separatorOrSeparators
+subStringsTrimmingTrailingEmptyElement: separatorOrSeparators
 	"Answer an array containing the substrings of the receiver separated by occurrences of the <Character> or <readableString> argument, separator.
-	Repeated separators produce empty strings in the array (cf. #subStrings). The separators are removed."
+	Repeated separators produce empty strings in the array (cf. #subStrings). The separators are removed.
+	If the last element is empty then is removed"
+	| nonLastEmptyElementArray |
 
-	^(self subStrings: separatorOrSeparators) select: [:each | each notEmpty]! !
-!String categoriesFor: #nonEmptySubStrings:!copying!public! !
+	nonLastEmptyElementArray := self subStrings: separatorOrSeparators.
+	nonLastEmptyElementArray isEmpty ifTrue: [^nonLastEmptyElementArray].
+
+	nonLastEmptyElementArray last isEmpty ifTrue: [^nonLastEmptyElementArray allButLast].
+
+	^nonLastEmptyElementArray! !
+!String categoriesFor: #subStringsTrimmingTrailingEmptyElement:!copying!public! !
 
 "End of package definition"!
 

--- a/sources/GsObject.cls
+++ b/sources/GsObject.cls
@@ -135,12 +135,10 @@ fromXML: xmlElement session: gciSession
 !
 
 listFromString: aString session: aGciSession
-
 	| list |
-	list := aString nonEmptySubStrings: Character lf.
-	list := list collect: [:each | self fromString: each session:  aGciSession].
-	^list.
-!
+	list := aString subStringsTrimmingTrailingEmptyElement: Character lf.
+	list := list collect: [:each | self fromString: each session: aGciSession].
+	^list!
 
 xmlBaseName
 

--- a/sources/GsUserProfile.cls
+++ b/sources/GsUserProfile.cls
@@ -48,16 +48,17 @@ editPrivilege: anArray value: aBoolean
 !
 
 groupList
-
 	| string list |
-	string := gciSession
-		serverPerform: #'groupListFor:'
-		with: self.
-	list := string nonEmptySubStrings: Character lf.
+	string := gciSession serverPerform: #groupListFor: with: self.
+	list := string subStringsTrimmingTrailingEmptyElement: Character lf.
 	list := list collect: [:each | each subStrings: Character tab].
-	list := list collect: [:each | Array with: self with: (each at: 1) with: ((each at: 2) = 'true')].
-	^list.
-!
+	list := list collect: 
+					[:each |
+					Array
+						with: self
+						with: (each at: 1)
+						with: (each at: 2) = 'true'].
+	^list!
 
 initialize: aList
 
@@ -105,16 +106,17 @@ maxSessions
 !
 
 privilegeList
-
 	| string list |
-	string := gciSession
-		serverPerform: #'privilegeListFor:'
-		with: self.
-	list := string nonEmptySubStrings: Character lf.
+	string := gciSession serverPerform: #privilegeListFor: with: self.
+	list := string subStringsTrimmingTrailingEmptyElement: Character lf.
 	list := list collect: [:each | each subStrings: Character tab].
-	list := list collect: [:each | Array with: self with: (each at: 1) with: ((each at: 2) = 'true')].
-	^list.
-!
+	list := list collect: 
+					[:each |
+					Array
+						with: self
+						with: (each at: 1)
+						with: (each at: 2) = 'true'].
+	^list!
 
 remainingLogins
 
@@ -122,16 +124,12 @@ remainingLogins
 !
 
 symbolList
-
 	| string list |
-	string := gciSession
-		serverPerform: #'dictionaryListFor:'
-		with: self.
+	string := gciSession serverPerform: #dictionaryListFor: with: self.
 	string := gciSession decode: string.
-	list := string nonEmptySubStrings: Character lf.
+	list := string subStringsTrimmingTrailingEmptyElement: Character lf.
 	list := list collect: [:each | GsSymbolDictionary new initialize: each session: gciSession].
-	^list.
-! !
+	^list! !
 !GsUserProfile categoriesFor: #disabledReason!public! !
 !GsUserProfile categoriesFor: #editGroup:value:!public! !
 !GsUserProfile categoriesFor: #editPrivilege:value:!public! !
@@ -150,12 +148,10 @@ symbolList
 !GsUserProfile class methodsFor!
 
 allIn: aGciSession
-
 	| string list |
-	(string := aGciSession serverPerform: #'userList') isNil ifTrue: [^#()].
-	list := string nonEmptySubStrings: Character lf.
+	(string := aGciSession serverPerform: #userList) isNil ifTrue: [^#()].
+	list := string subStringsTrimmingTrailingEmptyElement: Character lf.
 	list := list collect: [:each | self new initialize: each session: aGciSession].
-	^list.
-! !
+	^list! !
 !GsUserProfile class categoriesFor: #allIn:!public! !
 

--- a/sources/JadeProcessBrowser.cls
+++ b/sources/JadeProcessBrowser.cls
@@ -109,18 +109,20 @@ terminate9
 !
 
 update
-
 	| string lines priorities |
-	string := gciSession serverPerform: #'processes'.
+	string := gciSession serverPerform: #processes.
 	string ifNil: [^self].
-	lines := (string nonEmptySubStrings: Character lf) asOrderedCollection.
-	priorities := lines removeFirst nonEmptySubStrings: Character tab.
-	priorities := priorities collect: [:each | | pieces | pieces := each subStrings: Character space. pieces first -> pieces last asNumber].
+	lines := (string subStringsTrimmingTrailingEmptyElement: Character lf) asOrderedCollection.
+	priorities := lines removeFirst subStringsTrimmingTrailingEmptyElement: Character tab.
+	priorities := priorities collect: 
+					[:each |
+					| pieces |
+					pieces := each subStrings: Character space.
+					pieces first -> pieces last asNumber].
 	priorities := priorities asSortedCollection: [:a :b | a value > b value].
 	prioritiesPresenter model list: priorities.
 	lines := lines collect: [:each | (each subStrings: Character tab) , #('?' '?')].
-	processesPresenter model list: lines.
-! !
+	processesPresenter model list: lines! !
 !JadeProcessBrowser categoriesFor: #createComponents!private! !
 !JadeProcessBrowser categoriesFor: #createSchematicWiring!private! !
 !JadeProcessBrowser categoriesFor: #debugProcess!private! !

--- a/sources/JadeSystemBrowserPresenter.cls
+++ b/sources/JadeSystemBrowserPresenter.cls
@@ -1157,19 +1157,19 @@ findClass
 !
 
 findClassList
-"
+	"
 	Array with: className with: dictionaryName with: catetory with: packageName.
 "
+
 	| string list |
-	string := self gciSession 
-		serverPerform: #'systemBrowser:' 
-		with: environment printString , ' findClass'.
-	list := (string nonEmptySubStrings: Character lf) collect: [:each | each subStrings: Character tab].
+	string := self gciSession serverPerform: #systemBrowser:
+				with: environment printString , ' findClass'.
+	list := (string subStringsTrimmingTrailingEmptyElement: Character lf)
+				collect: [:each | each subStrings: Character tab].
 	list := list copyFrom: 2 to: list size.
 	list := list collect: [:each | each size < 3 ifTrue: [each , #('' '' '')] ifFalse: [each]].
 	list := list collect: [:each | (each at: 1) -> each].
-	^list
-!
+	^list!
 
 gciSession: aGciSession
 

--- a/sources/MCRepositoryBrowser.cls
+++ b/sources/MCRepositoryBrowser.cls
@@ -113,27 +113,19 @@ fileTypes
 !
 
 getLoadedVersionNames
-
 	| string list |
-	(string := gciSession serverPerform: #'mcLoadedVersionNames') isNil ifTrue: [^self].
+	(string := gciSession serverPerform: #mcLoadedVersionNames) isNil ifTrue: [^self].
 	loadedVersionNames := Dictionary new.
-	list := string nonEmptySubStrings: Character lf.
+	list := string subStringsTrimmingTrailingEmptyElement: Character lf.
 	list := list collect: [:each | each subStrings: Character tab].
-	list do: [:each | 
-		| i name version |
-		string := each at: 1.
-		i := string findLast: [:char | char = $-].
-		name := i = 0 
-			ifTrue: [string]
-			ifFalse: [string copyFrom: 1 to: i - 1].
-		version := i = 0
-			ifTrue: ['']
-			ifFalse: [string copyFrom: i + 1 to: string size].
-		loadedVersionNames
-			at: name
-			put: version -> ((each at: 2) = 'Y').
-	].
-!
+	list do: 
+			[:each |
+			| i name version |
+			string := each at: 1.
+			i := string findLast: [:char | char = $-].
+			name := i = 0 ifTrue: [string] ifFalse: [string copyFrom: 1 to: i - 1].
+			version := i = 0 ifTrue: [''] ifFalse: [string copyFrom: i + 1 to: string size].
+			loadedVersionNames at: name put: version -> ((each at: 2) = 'Y')]!
 
 loadVersion
 


### PR DESCRIPTION
@jgfoster i just basically renamed nonEmptySubStrings: to subStringsTrimmingTrailingEmptyElement: and then i updated its implementation.
Is your implementation like this one ?
Now the last element is removed if it is empty:
```
subStringsTrimmingTrailingEmptyElement: separatorOrSeparators
	"Answer an array containing the substrings of the receiver separated by occurrences of the <Character> or <readableString> argument, separator.
	Repeated separators produce empty strings in the array (cf. #subStrings). The separators are removed.
	If the last element is empty then is removed"
	| nonLastEmptyElementArray |
	nonLastEmptyElementArray := self subStrings: separatorOrSeparators.
	nonLastEmptyElementArray isEmpty ifTrue: [^nonLastEmptyElementArray].
	nonLastEmptyElementArray last isEmpty ifTrue: [^nonLastEmptyElementArray allButLast].
	^nonLastEmptyElementArray
``` 