### PR TITLE
Fix #266

### DIFF
--- a/sources/JadeMethodListPresenter.cls
+++ b/sources/JadeMethodListPresenter.cls
@@ -252,9 +252,9 @@ updateSaveMethodOop: anInteger
 
  	methodListPresenter primaryPresenter model remove: methodListPresenter selectedMethod ifAbsent: [].
 
-	methodSourcePresenter gsMethod: (GsMethod fromGsMethod2: newGsMethod).
+	methodSourcePresenter gsMethod: (GsMethod fromGsMethod2: newGsMethod). "fix #266"
 	methodListPresenter primaryPresenter selection: newGsMethod.
-	methodListPresenter primaryPresenter model list reSort.!
+	methodListPresenter primaryPresenter model list reSort. "to preserve the original order"!
 
 updateSource
 "

--- a/sources/JadeMethodListPresenter.cls
+++ b/sources/JadeMethodListPresenter.cls
@@ -252,8 +252,9 @@ updateSaveMethodOop: anInteger
 
  	methodListPresenter primaryPresenter model remove: methodListPresenter selectedMethod ifAbsent: [].
 
+	methodSourcePresenter gsMethod: (GsMethod fromGsMethod2: newGsMethod).
 	methodListPresenter primaryPresenter selection: newGsMethod.
-!
+	methodListPresenter primaryPresenter model list reSort.!
 
 updateSource
 "

--- a/sources/MethodSourcePresenter.cls
+++ b/sources/MethodSourcePresenter.cls
@@ -145,7 +145,6 @@ fileSave
 !
 
 gsMethod: aGsMethod
-
 	gsMethod := aGsMethod.
 	self update.!
 


### PR DESCRIPTION
@jgfoster the following line fix #266 
JadeMethodListPresenter>>updateSaveMethodOop:
`methodSourcePresenter gsMethod: (GsMethod fromGsMethod2: newGsMethod). "fix #266"`
I think in some cases `JadeMethodListPresenter>>updateSource` load the removed method and this cause the error.
This is preliminary because i did not research too much.
But after this change the error stop from happening. 
Also i added `reSort` to the underline collection because it was a little annoying when you have a large list of methods and modify one and goes to end of the list.