### PR TITLE
Fixed default font funkiness per Issue #276

### DIFF
--- a/sources/JadeCurrentSessionPreference.cls
+++ b/sources/JadeCurrentSessionPreference.cls
@@ -26,7 +26,9 @@ defaultFont
 	^View desktop font!
 
 defaultFont: aFont
-	View desktop font: aFont!
+	(View desktop font = aFont) ifFalse: [
+		View desktop font: aFont
+	].!
 
 displayString
 	^'Current Session'!

--- a/sources/JadePreferencesPresenter.cls
+++ b/sources/JadePreferencesPresenter.cls
@@ -154,7 +154,9 @@ defaultFont
 
 defaultFont: aFont
 
-	View desktop font: aFont.
+	(View desktop font = aFont) ifFalse: [ 
+		View desktop font: aFont. 
+	].
 !
 
 resource_Default_view


### PR DESCRIPTION
For reasons not fully understood, putting some defensive coding around `JadePreferencesPresenter class >> defaultFont:` and `JadeCurrentSessionPreferences class >> defaultFont:` to only update the `View desktop font` if the proposed font is different from the current one seems to get rid of all manifestations of the mouseOver/repaint events causing some labels, tree views, and buttons to have the desktop font be changed into ugly bolded System font. Issue #276 is resolved by this fix, but it would be good to understand what exactly was happening under the hood on my machine to make it happen.